### PR TITLE
Fixing the styling on nuxt content highlights

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -142,7 +142,7 @@ hr {
   margin-top: 1.5rem;
 }
 
-pre[class*="language-"] {
+.nuxt-content-highlight {
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
- Adding margin below to space out any content after